### PR TITLE
[JITERA] Remove 'Update message status' API from MessageController

### DIFF
--- a/server/src/v1/Message/Controller/message.controller.ts
+++ b/server/src/v1/Message/Controller/message.controller.ts
@@ -28,14 +28,7 @@ export class MessageController {
 
     @ApiBearerAuth()
     @UseGuards(AuthGuard('jwt'))
-    @Patch(':messageId/status')
-    updateMessageStatus(
-        @Param('messageId') messageId: string,
-        @Headers('authorization') bearer: string,
-        @Body('status') status: string
-    ): Promise<StatusOk> {
-        return this.messageService.updateMessageStatus(messageId, jwtManipulationService.decodeJwtToken(bearer, 'username'), status);
-    }
+
     @ApiBearerAuth()
     @UseGuards(AuthGuard('jwt'))
     @Get('unread-message-info')


### PR DESCRIPTION
## Overview
This pull request removes the 'Update message status' API from the `MessageController`. The `updateMessageStatus` method has been deemed unnecessary and is being removed to streamline the codebase.

## Changes
- Deleted the `updateMessageStatus` method from the `MessageController` class located at `/server/src/v1/Message/Controller/message.controller.ts`.

This change will help in reducing the complexity of the controller and improve maintainability. Please review the changes and let me know if there are any concerns.
